### PR TITLE
verify email error

### DIFF
--- a/src/Pbc/Codeception/Module/WordPressHelper.php
+++ b/src/Pbc/Codeception/Module/WordPressHelper.php
@@ -61,6 +61,12 @@ class WordPressHelper extends CodeceptionModule
                     $I->fail("{$i} login attempts were made.");
                 }
                 continue;
+                //this should run after the failed try in case that wp asks to verify email.
+                try {
+                    $I->dontSee("Administration email verification");
+                } catch (\Exception $e) {
+                    $I->click('The email is correct');
+                }
             }
         }
     }


### PR DESCRIPTION
WP keeps asking to verify email although db was updated, the error still shows up intermittently.